### PR TITLE
Next2

### DIFF
--- a/classes/isafw.bbclass
+++ b/classes/isafw.bbclass
@@ -29,7 +29,7 @@ python do_analyse_sources() {
     import re, errno
     from isafw import *
     isafw_config = isafw.ISA_config()
-    
+
     isafw_config.proxy = d.getVar('HTTP_PROXY', True)
     if not isafw_config.proxy :
         isafw_config.proxy = d.getVar('http_proxy', True)
@@ -48,7 +48,7 @@ python do_analyse_sources() {
 
     whitelist = d.getVar('ISAFW_PLUGINS_WHITELIST', True)
     blacklist = d.getVar('ISAFW_PLUGINS_BLACKLIST', True)
-    if whitelist: 
+    if whitelist:
         isafw_config.plugin_whitelist = re.split(r'[,\s]*', whitelist)
     if blacklist:
         isafw_config.plugin_blacklist = re.split(r'[,\s]*', blacklist)
@@ -86,7 +86,7 @@ python do_analyse_sources() {
         spdlicense.append(canonical_license(d, l))
     recipe.licenses = spdlicense
     recipe.path_to_sources = workdir
-    
+
     for patch in src_patches(d):
         _,_,local,_,_,_=bb.fetch.decodeurl(patch)
         recipe.patch_files.append(os.path.basename(local))
@@ -147,7 +147,7 @@ python analyse_image() {
 
     whitelist = d.getVar('ISAFW_PLUGINS_WHITELIST', True)
     blacklist = d.getVar('ISAFW_PLUGINS_BLACKLIST', True)
-    if whitelist: 
+    if whitelist:
         isafw_config.plugin_whitelist = re.split(r'[,\s]*', whitelist)
     if blacklist:
         isafw_config.plugin_blacklist = re.split(r'[,\s]*', blacklist)

--- a/classes/isafw.bbclass
+++ b/classes/isafw.bbclass
@@ -215,7 +215,7 @@ python isafwreport_handler () {
 
     import shutil
 
-    logdir = d.getVar('ISAFW_LOGDIR', True)
+    logdir = e.data.getVar('ISAFW_LOGDIR', True)
     if os.path.exists(os.path.dirname(logdir+"/test")):
         shutil.rmtree(logdir)
     os.makedirs(os.path.dirname(logdir+"/test"))

--- a/classes/isafw.bbclass
+++ b/classes/isafw.bbclass
@@ -26,34 +26,9 @@ do_analyse_sources[cleandirs] = "${ISAFW_WORKDIR}"
 
 python do_analyse_sources() {
 
-    import re, errno
     from isafw import *
-    isafw_config = isafw.ISA_config()
 
-    isafw_config.proxy = d.getVar('HTTP_PROXY', True)
-    if not isafw_config.proxy :
-        isafw_config.proxy = d.getVar('http_proxy', True)
-    bb.debug(1, 'isafw: proxy is %s' % isafw_config.proxy)
-
-    isafw_config.timestamp = d.getVar('DATETIME', True)
-    isafw_config.reportdir = d.getVar('ISAFW_REPORTDIR', True) + "_" + isafw_config.timestamp
-    if not os.path.exists(os.path.dirname(isafw_config.reportdir + "/test")):
-        try:
-            os.makedirs(os.path.dirname(isafw_config.reportdir + "/test"))
-        except OSError as exc:
-            if exc.errno == errno.EEXIST and os.path.isdir(isafw_config.reportdir):
-                pass
-            else: raise
-    isafw_config.logdir = d.getVar('ISAFW_LOGDIR', True)
-
-    whitelist = d.getVar('ISAFW_PLUGINS_WHITELIST', True)
-    blacklist = d.getVar('ISAFW_PLUGINS_BLACKLIST', True)
-    if whitelist:
-        isafw_config.plugin_whitelist = re.split(r'[,\s]*', whitelist)
-    if blacklist:
-        isafw_config.plugin_blacklist = re.split(r'[,\s]*', blacklist)
-
-    imageSecurityAnalyser = isafw.ISA(isafw_config)
+    imageSecurityAnalyser = isafw_init(isafw, d)
 
     if not d.getVar('SRC_URI', True):
         # Recipe didn't fetch any sources, nothing to do here I assume?
@@ -119,40 +94,14 @@ python() {
 
 python analyse_image() {
 
-    import re, errno
+    from isafw import *
+
+    imageSecurityAnalyser = isafw_init(isafw, d)
 
     # Directory where the image's entire contents can be examined
     rootfsdir = d.getVar('IMAGE_ROOTFS', True)
 
     imagebasename = d.getVar('IMAGE_BASENAME', True)
-
-    from isafw import *
-    isafw_config = isafw.ISA_config()
-
-    isafw_config.timestamp = d.getVar('DATETIME', True)
-    isafw_config.reportdir = d.getVar('ISAFW_REPORTDIR', True) + "_" + isafw_config.timestamp
-    if not os.path.exists(os.path.dirname(isafw_config.reportdir + "/test")):
-        try:
-            os.makedirs(os.path.dirname(isafw_config.reportdir + "/test"))
-        except OSError as exc:
-            if exc.errno == errno.EEXIST and os.path.isdir(isafw_config.reportdir):
-                pass
-            else: raise
-    isafw_config.logdir = d.getVar('ISAFW_LOGDIR', True)
-
-    isafw_config.proxy = d.getVar('HTTP_PROXY', True)
-    if not isafw_config.proxy :
-        isafw_config.proxy = d.getVar('http_proxy', True)
-    bb.debug(1, 'isafw: proxy is %s' % isafw_config.proxy)
-
-    whitelist = d.getVar('ISAFW_PLUGINS_WHITELIST', True)
-    blacklist = d.getVar('ISAFW_PLUGINS_BLACKLIST', True)
-    if whitelist:
-        isafw_config.plugin_whitelist = re.split(r'[,\s]*', whitelist)
-    if blacklist:
-        isafw_config.plugin_blacklist = re.split(r'[,\s]*', blacklist)
-
-    imageSecurityAnalyser = isafw.ISA(isafw_config)
 
     pkglist = manifest2pkglist(d)
 
@@ -182,6 +131,36 @@ python analyse_image() {
 
 do_rootfs[depends] += "checksec-native:do_populate_sysroot"
 analyse_image[fakeroot] = "1"
+
+def isafw_init(isafw, d):
+    import re, errno
+
+    isafw_config = isafw.ISA_config()
+
+    isafw_config.proxy = d.getVar('HTTP_PROXY', True)
+    if not isafw_config.proxy :
+        isafw_config.proxy = d.getVar('http_proxy', True)
+    bb.debug(1, 'isafw: proxy is %s' % isafw_config.proxy)
+
+    isafw_config.timestamp = d.getVar('DATETIME', True)
+    isafw_config.reportdir = d.getVar('ISAFW_REPORTDIR', True) + "_" + isafw_config.timestamp
+    if not os.path.exists(os.path.dirname(isafw_config.reportdir + "/test")):
+        try:
+            os.makedirs(os.path.dirname(isafw_config.reportdir + "/test"))
+        except OSError as exc:
+            if exc.errno == errno.EEXIST and os.path.isdir(isafw_config.reportdir):
+                pass
+            else: raise
+    isafw_config.logdir = d.getVar('ISAFW_LOGDIR', True)
+
+    whitelist = d.getVar('ISAFW_PLUGINS_WHITELIST', True)
+    blacklist = d.getVar('ISAFW_PLUGINS_BLACKLIST', True)
+    if whitelist:
+        isafw_config.plugin_whitelist = re.split(r'[,\s]*', whitelist)
+    if blacklist:
+        isafw_config.plugin_blacklist = re.split(r'[,\s]*', blacklist)
+
+    return isafw.ISA(isafw_config)
 
 def manifest2pkglist(d):
 

--- a/lib/isafw/isaplugins/ISA_cve_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cve_plugin.py
@@ -66,7 +66,10 @@ class ISA_CVEChecker:
                 cve_patch_info = self.process_patch_list(ISA_pkg.patch_files)
                 with os.fdopen(fhandle[0], 'w') as fauxfile:
                     fauxfile.write(ISA_pkg.name + "," + ISA_pkg.version + "," + cve_patch_info + ",")
-                args = "https_proxy=%s http_proxy=%s cve-check-tool -N -c -a -t faux %s" % (self.proxy, self.proxy, ffauxfile)
+                args = ""
+                if self.proxy:
+                        args += "https_proxy=%s http_proxy=%s " % (self.proxy, self.proxy)
+                args += "cve-check-tool -N -c -a -t faux '" + ffauxfile + "'"
                 with open(self.logdir + log, 'a') as flog:
                     flog.write("\n\nArguments for calling cve-check-tool: " + args)
                 try:

--- a/lib/isafw/isaplugins/ISA_fsa_plugin.py
+++ b/lib/isafw/isaplugins/ISA_fsa_plugin.py
@@ -48,16 +48,17 @@ class ISA_FSChecker():
         self.no_sticky_bit_ww_dirs = []
         print("Plugin ISA_FSChecker initialized!")
         with open(self.logdir + log, 'w') as flog:
-            flog.write("Plugin ISA_FSChecker initialized!\n")
+            flog.write("\nPlugin ISA_FSChecker initialized!\n")
 
     def process_filesystem(self, ISA_filesystem):
         if (self.initialized == True):
             if (ISA_filesystem.img_name and ISA_filesystem.path_to_fs):
                 with open(self.logdir + log, 'a') as flog:
-                    flog.write("Analyzing filesystem at: " + ISA_filesystem.path_to_fs + " for the image: " + ISA_filesystem.img_name)
+                    flog.write("Analyzing filesystem at: " + ISA_filesystem.path_to_fs +
+                               " for the image: " + ISA_filesystem.img_name + "\n")
                 self.files = self.find_fsobjects(ISA_filesystem.path_to_fs)
                 with open(self.logdir + log, 'a') as flog:
-                    flog.write("\n\nFilelist is: " + str(self.files))
+                    flog.write("\nFilelist is: " + str(self.files))
                 with open(self.reportdir + full_report + ISA_filesystem.img_name + "_" + self.timestamp, 'w') as ffull_report:
                     ffull_report.write("Report for image: " + ISA_filesystem.img_name + '\n')
                     ffull_report.write("With rootfs location at " + ISA_filesystem.path_to_fs + "\n\n")

--- a/lib/isafw/isaplugins/ISA_kca_plugin.py
+++ b/lib/isafw/isaplugins/ISA_kca_plugin.py
@@ -159,14 +159,14 @@ class ISA_KernelChecker():
         self.initialized = True
         print("Plugin ISA_KernelChecker initialized!")
         with open(self.logdir + log, 'w') as flog:
-            flog.write("Plugin ISA_KernelChecker initialized!\n")
+            flog.write("\nPlugin ISA_KernelChecker initialized!\n")
 
     def process_kernel(self, ISA_kernel):
         if (self.initialized == True):
             if (ISA_kernel.img_name and ISA_kernel.path_to_config):
                 with open(self.logdir + log, 'a') as flog:
                     flog.write("Analyzing kernel config file at: " + ISA_kernel.path_to_config +
-                                 "for the image: " + ISA_kernel.img_name)
+                               " for the image: " + ISA_kernel.img_name + "\n")
                 with open(ISA_kernel.path_to_config, 'r') as fkernel_conf:
                     for line in fkernel_conf:
                         line = line.strip('\n')

--- a/recipes-devtools/cve-check-tool/cve-check-tool_5.6.bb
+++ b/recipes-devtools/cve-check-tool/cve-check-tool_5.6.bb
@@ -11,7 +11,7 @@ SRC_URI = "https://github.com/ikeydoherty/${BPN}/releases/download/v${PV}/${BP}.
 SRC_URI[md5sum] = "30f32e6254580162eacfcc437a144463"
 SRC_URI[sha256sum] = "d35af2bfa014b9d7cdc9c59ec0bd7df40c22dfcd57244c9099c0aa9bdc9c0cb4"
 
-DEPENDS = "libcheck glib-2.0 json-glib curl libxml2 sqlite3" 
+DEPENDS = "libcheck glib-2.0 json-glib curl libxml2 sqlite3 openssl"
 
 inherit pkgconfig autotools
 


### PR DESCRIPTION
I would like to merge these changes first. They introduce no intrusive functional changes to the layer and probably good candidate for merge for now. More changes, regarded to the report generation will came later.

Please test these changes and merge them if you found them useful.

Thanks.

Below you can find short description of the introduced changes:
- Enable build with bitbake 1.26. This will enable meta-security-isafw layer usage on fido branch (commit d83614d).
- Cosmetics change: make all lines end with LF instead of CR+LF. Rest of the files in the project uses LF as EOL (commit bf44af4).
- Remove code duplication in isafw.bbclass by abstracting out ISA object initialization (commit bf44af4).
- Adjust logging message formats for certain plugins (commit dc77c00).
- Fix proxy-less configuration environments by not adding http{,s}_proxy environment variables when calling cve-check-tool if self.proxy is set to None (which is considered as valid DNS name and used by libcurl as address of the HTTP(S) proxy).
- Starting from v5.6 cve-check-tool requires SHA256 function from openssl package for NVD XML files integrity checks against digest from NVD META file. Add this dependency explicitly.
