### PR TITLE
Next3

### DIFF
--- a/classes/isafw.bbclass
+++ b/classes/isafw.bbclass
@@ -83,8 +83,6 @@ addtask do_analysesource after do_unpack before do_build
 PR_ORIG_TASK := "${BB_DEFAULT_TASK}"
 BB_DEFAULT_TASK = "process_reports"
 
-do_process_reports[recrdeptask] = "do_analysesource"
-do_process_reports[recideptask] = "do_${PR_ORIG_TASK}"
 do_process_reports[nostamp] = "1"
 
 python do_process_reports() {

--- a/classes/isafw.bbclass
+++ b/classes/isafw.bbclass
@@ -118,8 +118,14 @@ do_analyse_sources_all() {
 }
 
 python() {
-    # We probably don't need to scan native/cross
-    if bb.data.inherits_class('native', d) or bb.data.inherits_class('cross', d):
+    # We probably don't need to scan these
+    if bb.data.inherits_class('native', d) or \
+       bb.data.inherits_class('nativesdk', d) or \
+       bb.data.inherits_class('cross', d) or \
+       bb.data.inherits_class('crosssdk', d) or \
+       bb.data.inherits_class('cross-canadian', d) or \
+       bb.data.inherits_class('packagegroup', d) or \
+       bb.data.inherits_class('image', d):
         bb.build.deltask('do_analysesource', d)
 }
 

--- a/lib/isafw/isafw.py
+++ b/lib/isafw/isafw.py
@@ -179,6 +179,24 @@ class ISA:
                 except:
                     print("Exception in plugin: ", sys.exc_info())
 
+    def process_report(self):
+        for name in isaplugins.__all__:
+            plugin = getattr(isaplugins, name)
+            try:
+                # see if the plugin has a 'process_report' attribute
+                process_report = plugin.process_report
+            except AttributeError:
+                # if it doesn't, it is ok, won't call this plugin
+                pass
+            else:
+                if self.ISA_config.plugin_whitelist and plugin.getPluginName() not in self.ISA_config.plugin_whitelist:
+                    continue
+                if self.ISA_config.plugin_blacklist and plugin.getPluginName() in self.ISA_config.plugin_blacklist:
+                    continue
+                try:
+                    process_report()
+                except:
+                    print("Exception in plugin: ", sys.exc_info())
 
 
 

--- a/lib/isafw/isaplugins/ISA_cve_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cve_plugin.py
@@ -82,12 +82,30 @@ class ISA_CVEChecker:
                 flog.write("Plugin hasn't initialized! Not performing the call.\n")
 
     def process_report(self):
+        print("Creating report in HTML format.")
+        with open(self.logdir + log, 'a') as flog:
+            flog.write("Creating report in HTML format.\n")
+        self.process_report_type("html")
+
+        print("Creating report in CSV format.")
+        with open(self.logdir + log, 'a') as flog:
+            flog.write("Creating report in CSV format.\n")
+        self.process_report_type("csv")
+
+        pkglist_faux = pkglist + "_" + self.timestamp + ".faux"
+        os.remove(self.reportdir + pkglist_faux)
+
+    def process_report_type(self, rtype):
         # now faux file is ready and we can process it
         args = ""
         if self.proxy:
             args += "https_proxy=%s http_proxy=%s " % (self.proxy, self.proxy)
+        args += "cve-check-tool "
+        if rtype != "html":
+            args += "-c "
+            rtype = "csv"
         pkglist_faux = pkglist + "_" + self.timestamp + ".faux"
-        args += "cve-check-tool -c -a -t faux '" + self.reportdir + pkglist_faux  + "'"
+        args += "-a -t faux '" + self.reportdir + pkglist_faux  + "'"
         try:
             popen = subprocess.Popen(args, shell=True, stdout=subprocess.PIPE)
             popen.wait()
@@ -98,10 +116,9 @@ class ISA_CVEChecker:
             with open(self.logdir + log, 'a') as flog:
                 flog.write("Error in executing cve-check-tool: " + sys.exc_info())
         else:
-            report = cve_report + "_" + self.timestamp + ".csv"
+            report = cve_report + "_" + self.timestamp + "." + rtype
             with open(self.reportdir + report, 'w') as freport:
                 freport.write(output)
-        os.remove(self.reportdir + pkglist_faux)
 
     def process_patch_list(self, patch_files):
         patch_info = ""


### PR DESCRIPTION
Hi, again. This is my continued v2 patch series. I would like to merge following changes into upstream:
- Process reports in one shot as last stage of **do_analyse_sources** and *_do_analyse_sources_all_ tasks, as well as default task (e.g. bitbake core-image-minimal) (commit 18aba3a).
- Enable HTML reports in ISA_cve_plugin.py with additional cve-check-tool call. Now we have faux data file prepared by the **do_analysesource** internal task and we can call cve-check-tool multiple times to get required report types. Now we support CSV and HTML reports (commit 17fdb8b).
- Exclude more package classes from the **do_analysesource**. We already exclude _native_ and _cross_, add _nativesdk_, _crosssdk_, _cross-canadian_, _packagegroup_ and _image_ classes (commit dfa2597).

I've made tests against YOCTO jethro branch. Following tests are passed.

bitbake -c analyse_sources openssl
bitbake -c analyse_sources_all core-image-minimal
bitbake core-image-minimal (on already build image, nostamp isn't used in new patches).

Please test.
