### PR TITLE
Taking pkg alias info into use in CVE plugin:

### DIFF
--- a/classes/isafw.bbclass
+++ b/classes/isafw.bbclass
@@ -9,6 +9,8 @@
 
 LICENSE = "MIT"
 
+require conf/distro/include/distro_alias.inc
+
 ISAFW_WORKDIR = "${WORKDIR}/isafw"
 ISAFW_REPORTDIR ?= "${LOG_DIR}/isafw-report"
 ISAFW_LOGDIR ?= "${LOG_DIR}/isafw-logs"
@@ -46,6 +48,8 @@ python do_analysesource() {
     recipe = isafw.ISA_package()
     recipe.name = d.getVar('PN', True)
     recipe.version = d.getVar('PV', True)
+    recipe.version = recipe.version.split('+git', 1)[0]
+
     licenses = d.getVar('LICENSE', True)
     licenses = licenses.replace("(", "")
     licenses = licenses.replace(")", "")
@@ -59,6 +63,17 @@ python do_analysesource() {
     for l in recipe.licenses:
         spdlicense.append(canonical_license(d, l))
     recipe.licenses = spdlicense
+
+    aliases = d.getVar('DISTRO_PN_ALIAS', True)
+    if aliases:
+        recipe.aliases = aliases.split()
+        faliases = []
+        for a in recipe.aliases:
+            faliases.append(a.split('=', 1)[-1])
+        # remove possible duplicates in pkg names
+        faliases = list(set(faliases))
+        recipe.aliases = faliases
+
     recipe.path_to_sources = workdir
 
     for patch in src_patches(d):

--- a/classes/isafw.bbclass
+++ b/classes/isafw.bbclass
@@ -69,7 +69,8 @@ python do_analysesource() {
         recipe.aliases = aliases.split()
         faliases = []
         for a in recipe.aliases:
-            faliases.append(a.split('=', 1)[-1])
+            if (a != "OSPDT") and (not (a.startswith("upstream="))):
+                faliases.append(a.split('=', 1)[-1])
         # remove possible duplicates in pkg names
         faliases = list(set(faliases))
         recipe.aliases = faliases

--- a/lib/isafw/isafw.py
+++ b/lib/isafw/isafw.py
@@ -47,6 +47,7 @@ class ISA_package:
     name = ""                     # pkg name                            (mandatory argument)
     version = ""                  # full version                        (mandatory argument)
     licenses = []                 # list of licences for all subpackages
+    aliases = []                  # list of alias names for packages if exist
     source_files = []             # list of strings of source files 
     patch_files = []              # list of patch files to be applied
     path_to_sources = ""          # path to the source files

--- a/lib/isafw/isaplugins/ISA_cve_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cve_plugin.py
@@ -60,13 +60,18 @@ class ISA_CVEChecker:
     def process_package(self, ISA_pkg):
         if (self.initialized == True):
             if (ISA_pkg.name and ISA_pkg.version and ISA_pkg.patch_files):
+                alias_pkgs_faux = []
                 # need to compose faux format line for cve-check-tool
                 cve_patch_info = self.process_patch_list(ISA_pkg.patch_files)
                 pkgline_faux = ISA_pkg.name + "," + ISA_pkg.version + "," + cve_patch_info + ",\n"
-
+                if ISA_pkg.aliases:
+                    for a in ISA_pkg.aliases:
+                        alias_pkgs_faux.append(a + "," + ISA_pkg.version + "," + cve_patch_info + ",\n")
                 pkglist_faux = pkglist + "_" + self.timestamp + ".faux"
                 with open(self.reportdir + pkglist_faux, 'a') as fauxfile:
                     fauxfile.write(pkgline_faux)
+                    for a in alias_pkgs_faux:
+                        fauxfile.write(a)
 
                 with open(self.logdir + log, 'a') as flog:
                     flog.write("\npkg info: " + pkgline_faux)


### PR DESCRIPTION
- Passing the pkg alias information from build system
- Fixing the pkg version passing for "+git***" versions
- CVE plugin: pass pkg alias information to cve-check-tool
