### PR TITLE
Moving process_report to execute as handler and cleaning plugin output

### DIFF
--- a/classes/isafw.bbclass
+++ b/classes/isafw.bbclass
@@ -97,13 +97,12 @@ addtask do_analysesource after do_unpack before do_build
 # This task intended to be called after default task to process reports
 
 PR_ORIG_TASK := "${BB_DEFAULT_TASK}"
-BB_DEFAULT_TASK = "process_reports"
+addhandler process_reports_handler
+process_reports_handler[eventmask] = "bb.event.BuildCompleted"
 
-do_process_reports[nostamp] = "1"
+python process_reports_handler() {
 
-python do_process_reports() {
-
-    from isafw import *
+    from isafw import isafw
 
     imageSecurityAnalyser = isafw_init(isafw, d)
 
@@ -111,14 +110,12 @@ python do_process_reports() {
     imageSecurityAnalyser.process_report()
 }
 
-addtask do_process_reports after do_${PR_ORIG_TASK}
 
 # These tasks are intended to be called directly by the user (e.g. bitbake -c)
 
 addtask do_analyse_sources after do_analysesource
 do_analyse_sources[doc] = "Produce ISAFW reports based on given package without building it"
 do_analyse_sources[nostamp] = "1"
-do_analyse_sources[postfuncs] = "do_process_reports"
 do_analyse_sources() {
 	:
 }
@@ -128,7 +125,6 @@ do_analyse_sources_all[doc] = "Produce ISAFW reports for all packages in given t
 do_analyse_sources_all[recrdeptask] = "do_analyse_sources_all do_analysesource"
 do_analyse_sources_all[recideptask] = "do_${PR_ORIG_TASK}"
 do_analyse_sources_all[nostamp] = "1"
-do_analyse_sources_all[postfuncs] = "do_process_reports"
 do_analyse_sources_all() {
 	:
 }

--- a/classes/isafw.bbclass
+++ b/classes/isafw.bbclass
@@ -104,10 +104,14 @@ python process_reports_handler() {
 
     from isafw import isafw
 
-    imageSecurityAnalyser = isafw_init(isafw, d)
+    savedenv = os.environ.copy()
+    os.environ["PATH"] = d.getVar("PATH", True)
 
+    imageSecurityAnalyser = isafw_init(isafw, d)
     bb.debug(1, 'isafw: process reports')
     imageSecurityAnalyser.process_report()
+
+    os.environ["PATH"] = savedenv["PATH"]
 }
 
 

--- a/lib/isafw/isaplugins/ISA_cfa_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cfa_plugin.py
@@ -54,26 +54,25 @@ class ISA_CFChecker():
         self.problems_report_name = ISA_config.reportdir + "/cfa_problems_report_" + ISA_config.machine + "_" + ISA_config.timestamp
         self.full_reports = ISA_config.full_reports
         # check that checksec is installed
-        rc = subprocess.call(["which", "checksec.sh"])
+        DEVNULL = open(os.devnull, 'wb')
+        rc = subprocess.call(["which", "checksec.sh"], stdout=DEVNULL)
         if rc == 0:
             # check that execstack is installed
-            rc = subprocess.call(["which", "execstack"])
+            rc = subprocess.call(["which", "execstack"], stdout=DEVNULL)
             if rc == 0:
                 # check that execstack is installed
-                rc = subprocess.call(["which", "readelf"])
+                rc = subprocess.call(["which", "readelf"], stdout=DEVNULL)
                 if rc == 0:
                     self.initialized = True
-                    print("Plugin ISA_CFChecker initialized!")
                     with open(self.logfile, 'w') as flog:
                         flog.write("\nPlugin ISA_CFChecker initialized!\n")
+                        DEVNULL.close()
                     return
-        print("checksec, execstack or readelf tools are missing!")
-        print("Please install checksec from http://www.trapkit.de/tools/checksec.html")
-        print("Please install execstack from prelink package")
         with open(self.logfile, 'w') as flog:
             flog.write("checksec, execstack or readelf tools are missing!\n")
             flog.write("Please install checksec from http://www.trapkit.de/tools/checksec.html\n")
             flog.write("Please install execstack from prelink package\n")
+        DEVNULL.close()
 
     def process_filesystem(self, ISA_filesystem):
         if (self.initialized == True):
@@ -91,13 +90,10 @@ class ISA_CFChecker():
                 self.write_report(ISA_filesystem)
                 self.write_report_xml(ISA_filesystem)
             else:
-                print("Mandatory arguments such as image name and path to the filesystem are not provided!")
-                print("Not performing the call.")
                 with open(self.logfile, 'a') as flog:
                     flog.write("Mandatory arguments such as image name and path to the filesystem are not provided!\n")
                     flog.write("Not performing the call.\n")
         else:
-            print("Plugin hasn't initialized! Not performing the call.")
             with open(self.logfile, 'a') as flog:
                 flog.write("Plugin hasn't initialized! Not performing the call.\n")
 

--- a/lib/isafw/isaplugins/ISA_cve_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cve_plugin.py
@@ -42,18 +42,24 @@ class ISA_CVEChecker:
         self.timestamp = ISA_config.timestamp
         self.logfile = ISA_config.logdir + "/isafw_cvelog"
         self.report_name = ISA_config.reportdir + "/cve_report_" + ISA_config.machine + "_" + ISA_config.timestamp  
+        output = ""
         # check that cve-check-tool is installed
-        DEVNULL = open(os.devnull, 'wb')
-        rc = subprocess.call(["which", "cve-check-tool"], stdout=DEVNULL)
-        DEVNULL.close()
-        if rc == 0:
-            self.initialized = True
+        try:
+            popen = subprocess.Popen("which cve-check-tool", shell=True, stdout=subprocess.PIPE)
+            popen.wait()
+            output = popen.stdout.read()
+        except:
             with open(self.logfile, 'a') as flog:
-                flog.write("\nPlugin ISA_CVEChecker initialized!\n")
+                flog.write("error executing which cve-check-tool\n")
         else:
-            with open(self.logfile, 'a') as flog:
-                flog.write("cve-check-tool is missing!\n")
-                flog.write("Please install it from https://github.com/ikeydoherty/cve-check-tool.\n")
+            if output:
+                self.initialized = True
+                with open(self.logfile, 'a') as flog:
+                    flog.write("\nPlugin ISA_CVEChecker initialized!\n")
+            else:
+                with open(self.logfile, 'a') as flog:
+                    flog.write("cve-check-tool is missing!\n")
+                    flog.write("Please install it from https://github.com/ikeydoherty/cve-check-tool.\n")
 
     def process_package(self, ISA_pkg):
         if (self.initialized == True):

--- a/lib/isafw/isaplugins/ISA_cve_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cve_plugin.py
@@ -43,15 +43,14 @@ class ISA_CVEChecker:
         self.logfile = ISA_config.logdir + "/isafw_cvelog"
         self.report_name = ISA_config.reportdir + "/cve_report_" + ISA_config.machine + "_" + ISA_config.timestamp  
         # check that cve-check-tool is installed
-        rc = subprocess.call(["which", "cve-check-tool"])
+        DEVNULL = open(os.devnull, 'wb')
+        rc = subprocess.call(["which", "cve-check-tool"], stdout=DEVNULL)
+        DEVNULL.close()
         if rc == 0:
             self.initialized = True
-            print("Plugin ISA_CVEChecker initialized!")
             with open(self.logfile, 'a') as flog:
                 flog.write("\nPlugin ISA_CVEChecker initialized!\n")
         else:
-            print("cve-check-tool is missing!")
-            print("Please install it from https://github.com/ikeydoherty/cve-check-tool.")
             with open(self.logfile, 'a') as flog:
                 flog.write("cve-check-tool is missing!\n")
                 flog.write("Please install it from https://github.com/ikeydoherty/cve-check-tool.\n")
@@ -75,25 +74,22 @@ class ISA_CVEChecker:
                 with open(self.logfile, 'a') as flog:
                     flog.write("\npkg info: " + pkgline_faux)
             else:
-                print("Mandatory arguments such as pkg name, version and list of patches are not provided!")
-                print("Not performing the call.")
                 self.initialized = False
                 with open(self.logfile, 'a') as flog:
                     flog.write("Mandatory arguments such as pkg name, version and list of patches are not provided!\n")
                     flog.write("Not performing the call.\n")
         else:
-            print("Plugin hasn't initialized! Not performing the call.")
             with open(self.logfile, 'a') as flog:
                 flog.write("Plugin hasn't initialized! Not performing the call.\n")
 
     def process_report(self):
+        if not os.path.isfile(self.reportdir + pkglist + "_" + self.timestamp + ".faux"): 
+            return
         if (self.initialized == True):
-            print("Creating report in HTML format.")
             with open(self.logfile, 'a') as flog:
                 flog.write("Creating report in HTML format.\n")
             self.process_report_type("html")
 
-            print("Creating report in CSV format.")
             with open(self.logfile, 'a') as flog:
                 flog.write("Creating report in CSV format.\n")
             self.process_report_type("csv")
@@ -101,7 +97,6 @@ class ISA_CVEChecker:
             pkglist_faux = pkglist + "_" + self.timestamp + ".faux"
             os.remove(self.reportdir + pkglist_faux)
 
-            print("Creating report in XML format.")
             with open(self.logfile, 'a') as flog:
                 flog.write("Creating report in XML format.\n")
             self.write_report_xml()
@@ -140,7 +135,6 @@ class ISA_CVEChecker:
             popen.wait()
             output = popen.stdout.read()
         except:
-            print("Error in executing cve-check-tool: ", sys.exc_info())
             output = "Error in executing cve-check-tool"
             with open(self.logfile, 'a') as flog:
                 flog.write("Error in executing cve-check-tool: " + sys.exc_info())

--- a/lib/isafw/isaplugins/ISA_fsa_plugin.py
+++ b/lib/isafw/isaplugins/ISA_fsa_plugin.py
@@ -44,7 +44,6 @@ class ISA_FSChecker():
         self.setgid_files = []
         self.ww_files = []
         self.no_sticky_bit_ww_dirs = []
-        print("Plugin ISA_FSChecker initialized!")
         with open(self.logfile, 'w') as flog:
             flog.write("\nPlugin ISA_FSChecker initialized!\n")
 
@@ -80,13 +79,10 @@ class ISA_FSChecker():
                 self.write_problems_report(ISA_filesystem)
                 self.write_problems_report_xml(ISA_filesystem)
             else:
-                print("Mandatory arguments such as image name and path to the filesystem are not provided!")
-                print("Not performing the call.")
                 with open(self.logfile, 'a') as flog:
                     flog.write("Mandatory arguments such as image name and path to the filesystem are not provided!\n")
                     flog.write("Not performing the call.\n")
         else:
-            print("Plugin hasn't initialized! Not performing the call.")
             with open(self.logfile, 'a') as flog:
                 flog.write("Plugin hasn't initialized! Not performing the call.\n")
 

--- a/lib/isafw/isaplugins/ISA_kca_plugin.py
+++ b/lib/isafw/isaplugins/ISA_kca_plugin.py
@@ -157,7 +157,6 @@ class ISA_KernelChecker():
         self.problems_report_name = ISA_config.reportdir + "/kca_problems_report_" + ISA_config.machine + "_" + ISA_config.timestamp
         self.full_reports = ISA_config.full_reports
         self.initialized = True
-        print("Plugin ISA_KernelChecker initialized!")
         with open(self.logfile, 'w') as flog:
             flog.write("\nPlugin ISA_KernelChecker initialized!\n")
 
@@ -191,13 +190,12 @@ class ISA_KernelChecker():
                 self.write_problems_report(ISA_kernel)
 
             else:
-                print("Mandatory arguments such as image name and path to config are not provided!")
-                print("Not performing the call.")
                 with open(self.logfile, 'a') as flog:
                     flog.write("Mandatory arguments such as image name and path to config are not provided!\n")
                     flog.write("Not performing the call.\n")
         else:
-            print("Plugin hasn't initialized! Not performing the call.")    
+            with open(self.logdir + log, 'a') as flog:
+                flog.write("Plugin hasn't initialized! Not performing the call!\n")
 
     def write_full_report(self, ISA_kernel):
         if self.full_reports :      

--- a/lib/isafw/isaplugins/ISA_kca_plugin.py
+++ b/lib/isafw/isaplugins/ISA_kca_plugin.py
@@ -194,7 +194,7 @@ class ISA_KernelChecker():
                     flog.write("Mandatory arguments such as image name and path to config are not provided!\n")
                     flog.write("Not performing the call.\n")
         else:
-            with open(self.logdir + log, 'a') as flog:
+            with open(self.logfile, 'a') as flog:
                 flog.write("Plugin hasn't initialized! Not performing the call!\n")
 
     def write_full_report(self, ISA_kernel):
@@ -268,7 +268,7 @@ class ISA_KernelChecker():
                         freport.write(key + ' : ' + str(self.security_kco[key]) + '\n')
                         freport.write("Recommended value:\n")
                         freport.write(key + ' : ' + str(self.security_kco_ref[key]) + '\n')
-                        freport.write("\nIntegrity options that need improvement:\n")
+            freport.write("\nIntegrity options that need improvement:\n")
             for key in sorted(self.integrity_kco):
                 if (self.integrity_kco[key] != self.integrity_kco_ref[key]) :
                     valid = False

--- a/lib/isafw/isaplugins/ISA_la_plugin.py
+++ b/lib/isafw/isaplugins/ISA_la_plugin.py
@@ -45,14 +45,14 @@ class ISA_LicenseChecker():
         self.logfile = ISA_config.logdir + "/isafw_lalog"
         self.report_name = ISA_config.reportdir + "/la_problems_report_"  + ISA_config.machine + "_"+ ISA_config.timestamp
         # check that rpm is installed (supporting only rpm packages for now)
-        rc = subprocess.call(["which", "rpm"])        
+        DEVNULL = open(os.devnull, 'wb')
+        rc = subprocess.call(["which", "rpm"], stdout=DEVNULL)
+        DEVNULL.close()
         if rc == 0:
                 self.initialized = True
-                print("Plugin ISA_LicenseChecker initialized!")
                 with open(self.logfile, 'a') as flog:
                     flog.write("\nPlugin ISA_LA initialized!\n")
         else:
-            print("rpm tool is missing!")
             with open(self.logfile, 'a') as flog:
                 flog.write("rpm tool is missing!\n")
 
@@ -63,8 +63,6 @@ class ISA_LicenseChecker():
                     # need to determine licenses first
                     if (not ISA_pkg.source_files):
                         if (not ISA_pkg.path_to_sources):
-                            print("No path to sources or source file list is provided!")
-                            print("Not able to determine licenses for package: ", ISA_pkg.name)
                             self.initialized = False
                             with open(self.logfile, 'a') as flog:
                                 flog.write("No path to sources or source file list is provided!")
@@ -80,8 +78,6 @@ class ISA_LicenseChecker():
                                 popen.wait()
                                 ISA_pkg.licenses = popen.stdout.read().split()
                             except:
-                                print("Error in executing rpm query: ", sys.exc_info())
-                                print("Not able to process package: ", ISA_pkg.name)
                                 self.initialized = False
                                 with open(self.logfile, 'a') as flog:
                                     flog.write("Error in executing rpm query: " + sys.exc_info())
@@ -95,20 +91,16 @@ class ISA_LicenseChecker():
                         with open(self.report_name, 'a') as freport:
                             freport.write(ISA_pkg.name + ": " + l + "\n")
             else:
-                print("Mandatory argument package name is not provided!")
-                print("Not performing the call.")
                 self.initialized = False
                 with open(self.logfile, 'a') as flog:
                     flog.write("Mandatory argument package name is not provided!\n")
                     flog.write("Not performing the call.\n")
         else:
-            print("Plugin hasn't initialized! Not performing the call.")
             with open(self.logfile, 'a') as flog:
                 flog.write("Plugin hasn't initialized! Not performing the call.")
 
     def process_report(self):
         if (self.initialized == True):
-            print("Creating report in XML format.")
             with open(self.logfile, 'a') as flog:
                 flog.write("Creating report in XML format.\n")
             self.write_report_xml()


### PR DESCRIPTION
Currently there is an issue when running "bitbake my_image:do_build" : process_reports task is not executed. Moving the task to be a handler on bb.event.BuildCompleted event. Also, cleaning out the output of all plugins since they spit too much garbage. 
