### PR TITLE
Updating cve-check-tool to 5.6.2 release version

### DIFF
--- a/lib/isafw/isaplugins/ISA_cve_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cve_plugin.py
@@ -136,18 +136,19 @@ class ISA_CVEChecker:
             rtype = "csv"
         pkglist_faux = pkglist + "_" + self.timestamp + ".faux"
         args += "-a -t faux '" + self.reportdir + pkglist_faux  + "'"
+        with open(self.logfile, 'a') as flog:
+            flog.write("Args: " + args)
         try:
-            popen = subprocess.Popen(args, shell=True, stdout=subprocess.PIPE)
-            popen.wait()
-            output = popen.stdout.read()
+            popen = subprocess.Popen(args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            stdout_value = popen.communicate()[0]
         except:
-            output = "Error in executing cve-check-tool"
+            stdout_value = "Error in executing cve-check-tool"
             with open(self.logfile, 'a') as flog:
                 flog.write("Error in executing cve-check-tool: " + sys.exc_info())
         else:
             report = self.report_name + "." + rtype
             with open(report, 'w') as freport:
-                freport.write(output)
+                freport.write(stdout_value)
 
     def process_patch_list(self, patch_files):
         patch_info = ""

--- a/recipes-devtools/cve-check-tool/cve-check-tool_5.6.2.bb
+++ b/recipes-devtools/cve-check-tool/cve-check-tool_5.6.2.bb
@@ -6,10 +6,14 @@ SECTION = "Development/Tools"
 LICENSE = "GPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e8c1458438ead3c34974bc0be3a03ed6"
 
-SRC_URI = "https://github.com/ikeydoherty/${BPN}/releases/download/v${PV}/${BP}.tar.xz"
+#SRC_URI = "https://github.com/ikeydoherty/${BPN}/releases/download/v${PV}/${BP}.tar.xz"
 
-SRC_URI[md5sum] = "30f32e6254580162eacfcc437a144463"
-SRC_URI[sha256sum] = "d35af2bfa014b9d7cdc9c59ec0bd7df40c22dfcd57244c9099c0aa9bdc9c0cb4"
+#SRC_URI[md5sum] = "30f32e6254580162eacfcc437a144463"
+#SRC_URI[sha256sum] = "d35af2bfa014b9d7cdc9c59ec0bd7df40c22dfcd57244c9099c0aa9bdc9c0cb4"
+
+S = "${WORKDIR}/git"
+SRC_URI= "git://git@github.com/ikeydoherty/cve-check-tool.git;protocol=ssh"
+SRCREV = "15be7fdc591354309a778009c4726ad8bdf7df25"
 
 DEPENDS = "libcheck glib-2.0 json-glib curl libxml2 sqlite3 openssl"
 


### PR DESCRIPTION
This addresses issue with cve-check-tool producing empty reports
