### PR TITLE
cve-check-tool: Use anonymous HTTPS as GIT transport rather than SSH

### DIFF
--- a/recipes-devtools/cve-check-tool/cve-check-tool_5.6.2.bb
+++ b/recipes-devtools/cve-check-tool/cve-check-tool_5.6.2.bb
@@ -12,7 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=e8c1458438ead3c34974bc0be3a03ed6"
 #SRC_URI[sha256sum] = "d35af2bfa014b9d7cdc9c59ec0bd7df40c22dfcd57244c9099c0aa9bdc9c0cb4"
 
 S = "${WORKDIR}/git"
-SRC_URI= "git://git@github.com/ikeydoherty/cve-check-tool.git;protocol=ssh"
+SRC_URI= "git://git@github.com/ikeydoherty/cve-check-tool.git;protocol=https"
 SRCREV = "15be7fdc591354309a778009c4726ad8bdf7df25"
 
 DEPENDS = "libcheck glib-2.0 json-glib curl libxml2 sqlite3 openssl"


### PR DESCRIPTION
Fetching of cve-check-tool from git repo using ssh protocol as
transport isn't feasible for publicly accessible repositories
such as github. Fetches will fail unless ssh private key is available.

Use anonymous HTTPS as transport for GIT.

Signed-off-by: Sergey Popovich popovich_sergei@mail.ua
