### PR TITLE
plugins: python version safe ElementTree usage

### DIFF
--- a/lib/isafw/isaplugins/ISA_cfa_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cfa_plugin.py
@@ -32,7 +32,14 @@ import os
 import stat
 from re import compile
 from re import sub
-from lxml import etree
+try:
+    from lxml import etree
+except ImportError:
+    try:
+        import xml.etree.cElementTree as etree
+    except ImportError:
+        import xml.etree.ElementTree as etree
+
 
 CFChecker = None
 
@@ -179,7 +186,10 @@ class ISA_CFChecker():
                 etree.SubElement(tcase8, 'failure', message=item, type='violation')
         tree = etree.ElementTree(root)
         output = self.problems_report_name + "_" + ISA_filesystem.img_name + '.xml' 
-        tree.write(output, encoding= 'UTF-8', pretty_print=True, xml_declaration=True)
+        try:
+            tree.write(output, encoding='UTF-8', pretty_print=True, xml_declaration=True)
+        except TypeError:
+            tree.write(output, encoding='UTF-8', xml_declaration=True)
 
     def find_files(self, init_path):
         list_of_files = []

--- a/lib/isafw/isaplugins/ISA_cve_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cve_plugin.py
@@ -108,7 +108,13 @@ class ISA_CVEChecker:
             self.write_report_xml()
 
     def write_report_xml(self):
-        from lxml import etree
+        try:
+            from lxml import etree
+        except ImportError:
+            try:
+                import xml.etree.cElementTree as etree
+            except ImportError:
+                import xml.etree.ElementTree as etree
         numTests = 0
         root = etree.Element('testsuite', name='CVE_Plugin', tests='1')
         with open(self.report_name + ".csv", 'r') as f:
@@ -123,7 +129,11 @@ class ISA_CVEChecker:
         root.set('tests', str(numTests))
         tree = etree.ElementTree(root)
         output = self.report_name + '.xml' 
-        tree.write(output, encoding= 'UTF-8', pretty_print=True, xml_declaration=True)
+        try:
+            tree.write(output, encoding='UTF-8', pretty_print=True, xml_declaration=True)
+        except TypeError:
+            tree.write(output, encoding='UTF-8', xml_declaration=True)
+
 
     def process_report_type(self, rtype):
         # now faux file is ready and we can process it

--- a/lib/isafw/isaplugins/ISA_fsa_plugin.py
+++ b/lib/isafw/isaplugins/ISA_fsa_plugin.py
@@ -27,7 +27,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
 from stat import *
-from lxml import etree
+try:
+    from lxml import etree
+except ImportError:
+    try:
+        import xml.etree.cElementTree as etree
+    except ImportError:
+        import xml.etree.ElementTree as etree
+
 
 FSAnalyzer = None
 
@@ -124,7 +131,10 @@ class ISA_FSChecker():
                 failrs4 = etree.SubElement(tcase4, 'failure', message = item, type = 'violation')            
         tree = etree.ElementTree(root)
         output = self.problems_report_name + "_" + ISA_filesystem.img_name + '.xml' 
-        tree.write(output, encoding = 'UTF-8', pretty_print = True, xml_declaration = True)
+        try:
+            tree.write(output, encoding='UTF-8', pretty_print=True, xml_declaration=True)
+        except TypeError:
+            tree.write(output, encoding='UTF-8', xml_declaration=True)
 
     def find_fsobjects(self, init_path):
         list_of_files = []

--- a/lib/isafw/isaplugins/ISA_kca_plugin.py
+++ b/lib/isafw/isaplugins/ISA_kca_plugin.py
@@ -26,7 +26,14 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from lxml import etree
+try:
+    from lxml import etree
+except ImportError:
+    try:
+        import xml.etree.cElementTree as etree
+    except ImportError:
+        import xml.etree.ElementTree as etree
+
 
 KCAnalyzer = None
 
@@ -346,7 +353,11 @@ class ISA_KernelChecker():
                     failrs4 = etree.SubElement(tcase4, 'failure', message = msg4, type='violation')
         tree = etree.ElementTree(root)
         output = self.problems_report_name + "_" + ISA_kernel.img_name + '.xml' 
-        tree.write(output, encoding = 'UTF-8', pretty_print = True, xml_declaration = True)
+        try:
+            tree.write(output, encoding='UTF-8', pretty_print=True, xml_declaration=True)
+        except TypeError:
+            tree.write(output, encoding='UTF-8', xml_declaration=True)
+
 
 #======== supported callbacks from ISA =============#
 

--- a/lib/isafw/isaplugins/ISA_la_plugin.py
+++ b/lib/isafw/isaplugins/ISA_la_plugin.py
@@ -106,7 +106,13 @@ class ISA_LicenseChecker():
             self.write_report_xml()
 
     def write_report_xml(self):
-        from lxml import etree
+        try:
+            from lxml import etree
+        except ImportError:
+            try:
+                import xml.etree.cElementTree as etree
+            except ImportError:
+                import xml.etree.ElementTree as etree
         numTests = 0
         root = etree.Element('testsuite', name='LA_Plugin', tests='1')
         if os.path.isfile (self.report_name):
@@ -121,8 +127,11 @@ class ISA_LicenseChecker():
             numTests = 1
         root.set('tests', str(numTests))
         tree = etree.ElementTree(root)
-        output = self.report_name + '.xml' 
-        tree.write(output, encoding= 'UTF-8', pretty_print=True, xml_declaration=True)
+        output = self.report_name + '.xml'
+        try:
+            tree.write(output, encoding='UTF-8', pretty_print=True, xml_declaration=True)
+        except TypeError:
+            tree.write(output, encoding='UTF-8', xml_declaration=True)
 
 
     def find_files(self, init_path):


### PR DESCRIPTION
On hosts where lxml is not installed, fallback to cElementTree or
ElementTree implementations that should be available in python 2.5+
standard libraries.

Helps with errors like:
(<type 'exceptions.ImportError'>, ImportError('No module named lxml',), <traceback object at 0x7fd3b4934f80>)
(<type 'exceptions.ImportError'>, ImportError('No module named lxml',), <traceback object at 0x7fd3b4934ab8>)
(<type 'exceptions.ImportError'>, ImportError('No module named lxml',), <traceback object at 0x7fd3b4934248>)
