### PR TITLE
isafw.bblass: exclude DATETIME from isafw_init variable checksums

### DIFF
--- a/classes/isafw.bbclass
+++ b/classes/isafw.bbclass
@@ -26,6 +26,8 @@ do_analysesource[depends] += "python-lxml-native:do_populate_sysroot"
 do_analysesource[nostamp] = "1"
 do_analysesource[cleandirs] = "${ISAFW_WORKDIR}"
 
+isafw_init[vardepsexclude] = "DATETIME"
+
 python do_analysesource() {
 
     from isafw import *


### PR DESCRIPTION
After the most recent changes in bitbake siggen (bitbake rev:
0f50a18d7a0ea0d68edd8e5217e29111f4b1ea0b), do_analysesource
tasks started failing with

"do_analysesource: Taskhash mismatch hash1 verses hash2".

This is due to the way taskhash is now calculated to also include
variables' hashesh.

To fix the problem, make isafw_init variable hash stable by
excluding DATETIME when calculating the hash for it.

Signed-off-by: Mikko Ylinen mikko.ylinen@intel.com
