### PR TITLE
ISA_cve_plugin.py: tool output must be decoded under Python3

### DIFF
--- a/lib/isafw/isaplugins/ISA_cve_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cve_plugin.py
@@ -183,7 +183,7 @@ class ISA_CVEChecker:
                            str(sys.exc_info()))
         else:
             stdout_value = result[0]
-            tool_stderr_value = result[1]
+            tool_stderr_value = result[1].decode('utf-8')
             if not tool_stderr_value and popen.returncode == 0:
                 report = self.report_name + "." + rtype
                 with open(report, 'wb') as freport:


### PR DESCRIPTION
Under Python3, output from shell tools are byte strings.
We need to decode them (assuming utf-8 here) before they
can be used as normal strings.

This fixes this error:

  File
  ".../meta-security-isafw/lib/isafw/isaplugins/ISA_cve_plugin.py",
  line 193, in process_report_type
    "\ncve-check-tool terminated with exit code " + str(popen.returncode)
  TypeError: can't concat bytes to str

Signed-off-by: Patrick Ohly patrick.ohly@intel.com
