### PR TITLE
ISA_cve_plugin: error handling of 'cve' searches of patch filenames

### DIFF
--- a/lib/isafw/isaplugins/ISA_cve_plugin.py
+++ b/lib/isafw/isaplugins/ISA_cve_plugin.py
@@ -203,8 +203,12 @@ class ISA_CVEChecker:
                 if (patch1[0] == patch):
                     continue
             patchstripped = patch1[2].split('-')
-            patch_info += " CVE-" + \
-                patchstripped[1] + "-" + re.findall('\d+', patchstripped[2])[0]
+            try:
+                patch_info += " CVE-" + \
+                    patchstripped[1] + "-" + re.findall('\d+', patchstripped[2])[0]
+            except IndexError:
+                # string parsing attempt failed, so just skip this patch
+               continue
         return patch_info
 
 # ======== supported callbacks from ISA ============= #


### PR DESCRIPTION
Found during a source code scan for OpenXT ( http://openXT.org ).

This patch filename:
meta-selinux/recipes-security/selinux/libsemanage/libsemanage-Fix-execve-segfaults-on-Ubuntu.patch

unfortunately contains the substring 'cve' which confuses the tool
looking for CVE identifiers in patch filenames.
Ignore patches where the string parsing does not match.

Signed-off-by: Christopher Clark christopher.clark6@baesystems.com
