### PR TITLE
conf: change layer priority 1 -> 6.

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "security-isafw"
 BBFILE_PATTERN_security-isafw = "^${LAYERDIR}/"
-BBFILE_PRIORITY_security-isafw = "1"
+BBFILE_PRIORITY_security-isafw = "6"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers


### PR DESCRIPTION
Change layer priority to be greater than oe-core priority. This is because the patched version of the cve-checker-tool is then used instead of the vanilla version provided by oe-core.
