### PR TITLE
conf: set LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -13,3 +13,5 @@ BBFILE_PRIORITY_security-isafw = "6"
 LAYERVERSION_security-isafw = "1"
 
 LAYERDEPENDS_security-isafw = "core"
+
+LAYERSERIES_COMPAT_security-isafw = "sumo thud"


### PR DESCRIPTION
Yocto requires LAYERSERIES_COMPAT to be set since version 2.5 "Sumo".

Signed-off-by: Oleksandr Kravchuk <oleksandr.kravchuk@pelagicore.com>