### PR TITLE
Update layer.conf for warrior release

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -14,4 +14,4 @@ LAYERVERSION_security-isafw = "1"
 
 LAYERDEPENDS_security-isafw = "core"
 
-LAYERSERIES_COMPAT_security-isafw = "sumo thud"
+LAYERSERIES_COMPAT_security-isafw = "sumo thud warrior"


### PR DESCRIPTION
Needed to add warrior to the LAYERSERIES_COMPAT_security-isafw
Without it bitbake will complain when on the warrior release.
Signed-off-by: Jonothan Kane Jonothan.Kane@gmail.com